### PR TITLE
Updated oid version, bumped all relevant version numbers

### DIFF
--- a/cumberbatch/package.json
+++ b/cumberbatch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cumberbatch",
   "description": "crazy watcher stuff",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "homepage": "https://github.com/azulus/cumberbatch",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"
@@ -17,8 +17,8 @@
     "chokidar": "1.0.0-rc4",
     "kew": "0.3",
     "lru-cache": "2.5",
-    "oid": "0.5",
-    "minimagic": "0.03",
+    "oid": "1.2.0",
+    "minimagic": "0.3.1",
     "minimatch": "0.2.14",
     "xxhash": "0.2"
   },

--- a/grunt-cumberbatch/package.json
+++ b/grunt-cumberbatch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cumberbatch",
   "description": "grunt utils for cumberbatch",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/azulus/grunt-cumberbatch",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"
@@ -17,7 +17,7 @@
     "url": "https://github.com/azulus/cumberbatch.git"
   },
   "dependencies": {
-    "cumberbatch": "0.3.2",
+    "cumberbatch": "0.3.3",
     "grunt": "0.4.5",
     "kew": "0.4.0",
     "mkdirp": "0.5.0"

--- a/gyro/package.json
+++ b/gyro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gyro",
   "description": "cumberbatch-based build system",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "homepage": "https://github.com/azulus/cumberbatch",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "colors": "0.6",
-    "cumberbatch": "0.3.2",
+    "cumberbatch": "0.3.3",
     "grunt": "0.4.5",
     "lodash": "2.4.1"
   },

--- a/minimagic/package.json
+++ b/minimagic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minimagic",
   "description": "fast minimatching",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/azulus/minimagic",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"
@@ -14,7 +14,7 @@
     "url": "https://github.com/azulus/minimagic.git"
   },
   "dependencies": {
-    "oid": "0.5",
+    "oid": "1.2.0",
     "minimatch": "0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I bumped the `oid` dependency version to 1.2.0 to support the latest node versions. I bumped all minor version numbers for the packages I changed.